### PR TITLE
Feature/consultant time

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,4 @@
 import express from 'express';
-// import multer from 'multer';
 import cors from 'cors';
 import route from './routes';
 

--- a/src/controllers/consultantController.js
+++ b/src/controllers/consultantController.js
@@ -10,10 +10,10 @@ const ConsultantController = {
       const { uuid } = req.userData;
       const { availableTime } = req.body;
       const dataToSave = await availableTime.map((x) => ({
-        consultantUuid: uuid,
-        availableTime: x
+        consultant_uuid: uuid,
+        available_time: x
       }));
-      await AvailableTime.bulkCreate(dataToSave, { returning: true });
+      await AvailableTime.bulkCreate(dataToSave);
       return sendSuccessResponse(res, 200, 'operation successful');
     } catch (error) {
       console.log(error);
@@ -26,7 +26,7 @@ const ConsultantController = {
     try {
       const { consultantUuid } = req.query;
       const availableTimes = await AvailableTime.findAll({
-        where: { consultantUuid }
+        where: { consultant_uuid: consultantUuid }
       });
       return sendSuccessResponse(res, 200, availableTimes);
     } catch (error) {

--- a/src/controllers/consultantController.js
+++ b/src/controllers/consultantController.js
@@ -19,6 +19,20 @@ const ConsultantController = {
       console.log(error);
       return sendErrorResponse(res, 500, 'INTERNAL SERVER ERROR');
     }
+  },
+
+  //  get available days and time consultant
+  async getConsultantAvailableDays(req, res) {
+    try {
+      const { consultantUuid } = req.query;
+      const availableTimes = await AvailableTime.findAll({
+        where: { consultantUuid }
+      });
+      return sendSuccessResponse(res, 200, availableTimes);
+    } catch (error) {
+      console.log(error);
+      return sendErrorResponse(res, 500, 'INTERNAL SERVER ERROR');
+    }
   }
 };
 

--- a/src/controllers/consultantController.js
+++ b/src/controllers/consultantController.js
@@ -1,0 +1,25 @@
+import model from '../models';
+import { sendErrorResponse, sendSuccessResponse } from '../utils/sendResponse';
+
+const { AvailableTime } = model;
+
+
+const ConsultantController = {
+  async SubmitAvailableTime(req, res) {
+    try {
+      const { uuid } = req.userData;
+      const { availableTime } = req.body;
+      const dataToSave = await availableTime.map((x) => ({
+        consultantUuid: uuid,
+        availableTime: x
+      }));
+      await AvailableTime.bulkCreate(dataToSave, { returning: true });
+      return sendSuccessResponse(res, 200, 'operation successful');
+    } catch (error) {
+      console.log(error);
+      return sendErrorResponse(res, 500, 'INTERNAL SERVER ERROR');
+    }
+  }
+};
+
+export default ConsultantController;

--- a/src/database/migrations/20200520204856-create-available-time-table.js
+++ b/src/database/migrations/20200520204856-create-available-time-table.js
@@ -1,0 +1,30 @@
+
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('AvailableTimes', {
+    uuid: {
+      allowNull: false,
+      primaryKey: true,
+      type: Sequelize.UUID,
+      defaultValue: Sequelize.UUIDV4
+    },
+    consultant_uuid: {
+      allowNull: false,
+      type: Sequelize.UUID
+    },
+    available_time: {
+      allowNull: false,
+      type: Sequelize.STRING
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+
+  // eslint-disable-next-line no-unused-vars
+  down: (queryInterface, Sequelize) => queryInterface.dropTable('AvailableTimes')
+};

--- a/src/middlewares/SocketAuth.js
+++ b/src/middlewares/SocketAuth.js
@@ -12,7 +12,6 @@ const socketAuth = async (token, socket, io) => {
       attributes: {
         exclude: ['password']
       }
-      // include: ['token'],
     });
     if (!user) io.to(socket.id).emit('login_error', { message: 'User not found please sign up' });
     return user.dataValues;

--- a/src/middlewares/role.js
+++ b/src/middlewares/role.js
@@ -1,0 +1,8 @@
+import { sendErrorResponse } from '../utils/sendResponse';
+
+const checkConsultant = (req, res, next) => {
+  const { role } = req.userData;
+  return role === 'consultant' ? next() : sendErrorResponse(res, 422, 'ACCESS DENIED');
+};
+
+export default checkConsultant;

--- a/src/models/AvailableTime.js
+++ b/src/models/AvailableTime.js
@@ -1,0 +1,17 @@
+module.exports = (sequelize, DataTypes) => {
+  const AvailableTime = sequelize.define(
+    'AvailableTime',
+    {
+      uuid: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true
+      },
+      consultantUuid: DataTypes.UUID,
+      availableTime: DataTypes.STRING
+    },
+    {}
+  );
+  AvailableTime.associate = (models) => models;
+  return AvailableTime;
+};

--- a/src/models/AvailableTime.js
+++ b/src/models/AvailableTime.js
@@ -7,8 +7,8 @@ module.exports = (sequelize, DataTypes) => {
         defaultValue: DataTypes.UUIDV4,
         primaryKey: true
       },
-      consultantUuid: DataTypes.UUID,
-      availableTime: DataTypes.STRING
+      consultant_uuid: DataTypes.UUID,
+      available_time: DataTypes.STRING
     },
     {}
   );

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -7,9 +7,9 @@ import imageUpload from '../middlewares/imageUpload';
 
 const userRouter = express.Router();
 
-userRouter.post('/login', imageUpload.none, validator.login, validateRequest, AuthController.signin);
-userRouter.post('/signup-patient', imageUpload.none, validator.patientSignup, validateRequest, AuthController.signupPatient);
-userRouter.post('/signup-consultant', imageUpload.consultantSignup, validator.consultantSignup, validateRequest, AuthController.signupConsultant);
-userRouter.get('/verification/:token/:email', imageUpload.none, AuthController.verifyUser);
+userRouter.post('/auth/login', imageUpload.none, validator.login, validateRequest, AuthController.signin);
+userRouter.post('/auth/signup-patient', imageUpload.none, validator.patientSignup, validateRequest, AuthController.signupPatient);
+userRouter.post('/auth/signup-consultant', imageUpload.consultantSignup, validator.consultantSignup, validateRequest, AuthController.signupConsultant);
+userRouter.get('/auth/verification/:token/:email', imageUpload.none, AuthController.verifyUser);
 
 export default userRouter;

--- a/src/routes/consultant.js
+++ b/src/routes/consultant.js
@@ -7,5 +7,5 @@ import imageUpload from '../middlewares/imageUpload';
 const consultantRouter = express.Router();
 
 consultantRouter.post('/select-available-time', imageUpload.none, Auth, checkConsultant, ConsultantController.SubmitAvailableTime);
-
+consultantRouter.get('/available-time', Auth, ConsultantController.getConsultantAvailableDays);
 export default consultantRouter;

--- a/src/routes/consultant.js
+++ b/src/routes/consultant.js
@@ -1,0 +1,11 @@
+import express from 'express';
+import ConsultantController from '../controllers/consultantController';
+import Auth from '../middlewares/Auth';
+import checkConsultant from '../middlewares/role';
+import imageUpload from '../middlewares/imageUpload';
+
+const consultantRouter = express.Router();
+
+consultantRouter.post('/select-available-time', imageUpload.none, Auth, checkConsultant, ConsultantController.SubmitAvailableTime);
+
+export default consultantRouter;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import auth from './auth';
+import consultant from './consultant';
 
 export default (app) => {
   app.use(express.json());
@@ -10,8 +11,8 @@ export default (app) => {
     data: 'Welcome to safeHaven API'
   }));
 
-  app.use('/api/v1/auth', [
-    auth
+  app.use('/api/v1', [
+    auth, consultant
   ]);
 
   app.all('/*', (req, res) => res.status(404).send({


### PR DESCRIPTION
## Description
consultants should be able to choose available times backend.

Fixes #5 

## How Has This Been Tested?
1.  Clone/Pull/Fetch this branch.
2.  Run `npm install` to install the dependencies.
3.  Run `npm test` to run the tests.
4.  Test the `/api/v1/select-available-time` endpoint of the server with postman
5. Pass in an array of available time/days as string format as the request body
6. Test the `/api/v1/available-time` endpoint with postman to get the available days of a consultant by passing the uuid of the professional as req.query using `consultantUuid`

## Screenshots (if applicable, else remove this line / section)
None

## Checklist
<!--- Put an `x` in all the boxes that apply ! -->
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have added necessary inline code documentation
-   [x] I have added tests that prove my fix is effective and that this feature works
-   [x] New and existing unit tests pass locally with my changes
